### PR TITLE
Upgrade mock-res to work on node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "escape-html": "^1.0.1",
         "etag": "^1.6.0",
         "mock-express-request": "^0.1.1",
-        "mock-res": "^0.2.1",
+        "mock-res": "^0.3.3",
         "on-finished": "^2.2.1",
         "proxy-addr": "^1.0.8",
         "qs": "^2.4.2",


### PR DESCRIPTION
Fixes #3, makes tests pass on Node 6.